### PR TITLE
Fix some English variants

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var languages = [
 
 		variants: [
 			/^({{[^}]+}}\s*)*\[\[([^\]#|]+)[^\]]*\]\]\.*$/i,
-			/\s*{{(([^|]+ of)|(alt form))\|([^}|]+)/
+			/\s*{{(([^|]+ of)|(alt form))\|(en\|)?([^}|]+)/
 		],
 
 		searchDef: function(page) {


### PR DESCRIPTION
Currently getting the definition for e.g. "HOUSES" does not work, showing no definition found; this is because the regex is expecting something like `# {{plural of|house}}` rather than `# {{plural of|en|house}}`. This commit fixes this issue.